### PR TITLE
Merge

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ find_package(CUDA ${ZED_CUDA_VERSION} EXACT REQUIRED)
 ## Generate dynamic reconfigure parameters in the 'cfg' folder
 generate_dynamic_reconfigure_options(
         cfg/fira_esi_dynamic_cfg.cfg
+        cfg/vision_dynamic_reconfigure.cfg
 )
 
 ## The catkin_package macro generates cmake config files for your package

--- a/cfg/vision_dynamic_reconfigure.cfg
+++ b/cfg/vision_dynamic_reconfigure.cfg
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+PACKAGE = "dynamic_reconfigure"
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+gen = ParameterGenerator() 
+
+
+gen.add("line_threshold", int_t, 0, "line_threshold", 0, 0, 255)
+
+gen.add("BGR_min_yellow1", int_t, 0, "BGR_min_yellow1", 0, 0, 255)
+gen.add("BGR_min_yellow2", int_t, 0, "BGR_min_yellow2", 0, 0, 255)
+gen.add("BGR_min_yellow3", int_t, 0, "BGR_min_yellow3", 0, 0, 255)
+gen.add("BGR_max_yellow1", int_t, 0, "BGR_max_yellow1", 0, 0, 255)
+gen.add("BGR_max_yellow2", int_t, 0, "BGR_max_yellow2", 0, 0, 255)
+gen.add("BGR_max_yellow3", int_t, 0, "BGR_max_yellow3", 0, 0, 255)
+
+gen.add("BGR_min_red1", int_t, 0, "BGR_min_red1", 0, 0, 255)
+gen.add("BGR_min_red2", int_t, 0, "BGR_min_red2", 0, 0, 255)
+gen.add("BGR_min_red3", int_t, 0, "BGR_min_red3", 0, 0, 255)
+gen.add("BGR_max_red1", int_t, 0, "BGR_max_red1", 0, 0, 255)
+gen.add("BGR_max_red2", int_t, 0, "BGR_max_red2", 0, 0, 255)
+gen.add("BGR_max_red3", int_t, 0, "BGR_max_red3", 0, 0, 255)
+
+gen.add("BGR_min_blueH1", int_t, 0, "BGR_min_blueH1", 0, 0, 255)
+gen.add("BGR_min_blueH2", int_t, 0, "BGR_min_blueH2", 0, 0, 255)
+gen.add("BGR_min_blueH3", int_t, 0, "BGR_min_blueH3", 0, 0, 255)
+gen.add("BGR_max_blueH1", int_t, 0, "BGR_max_blueH1", 0, 0, 255)
+gen.add("BGR_max_blueH2", int_t, 0, "BGR_max_blueH2", 0, 0, 255)
+gen.add("BGR_max_blueH3", int_t, 0, "BGR_max_blueH3", 0, 0, 255)
+
+gen.add("BGR_min_redX1", int_t, 0, "BGR_min_redX1", 0, 0, 255)
+gen.add("BGR_min_redX2", int_t, 0, "BGR_min_redX2", 0, 0, 255)
+gen.add("BGR_min_redX3", int_t, 0, "BGR_min_redX3", 0, 0, 255)
+gen.add("BGR_max_redX1", int_t, 0, "BGR_max_redX1", 0, 0, 255)
+gen.add("BGR_max_redX2", int_t, 0, "BGR_max_redX2", 0, 0, 255)
+gen.add("BGR_max_redX3", int_t, 0, "BGR_max_redX3", 0, 0, 255)
+
+
+gen.add("HSV_min_yellow1", int_t, 0, "HSV_min_yellow1", 0, 0, 180)
+gen.add("HSV_min_yellow2", int_t, 0, "HSV_min_yellow2", 0, 0, 255)
+gen.add("HSV_min_yellow3", int_t, 0, "HSV_min_yellow3", 0, 0, 255)
+gen.add("HSV_max_yellow1", int_t, 0, "HSV_max_yellow1", 0, 0, 180)
+gen.add("HSV_max_yellow2", int_t, 0, "HSV_max_yellow2", 0, 0, 255)
+gen.add("HSV_max_yellow3", int_t, 0, "HSV_max_yellow3", 0, 0, 255)
+
+gen.add("HSV_min_red1", int_t, 0, "HSV_min_red1", 0, 0, 180)
+gen.add("HSV_min_red2", int_t, 0, "HSV_min_red2", 0, 0, 255)
+gen.add("HSV_min_red3", int_t, 0, "HSV_min_red3", 0, 0, 255)
+gen.add("HSV_max_red1", int_t, 0, "HSV_max_red1", 0, 0, 180)
+gen.add("HSV_max_red2", int_t, 0, "HSV_max_red2", 0, 0, 255)
+gen.add("HSV_max_red3", int_t, 0, "HSV_max_red3", 0, 0, 255)
+
+gen.add("HSV_min_blueH1", int_t, 0, "HSV_min_blueH1", 0, 0, 180)
+gen.add("HSV_min_blueH2", int_t, 0, "HSV_min_blueH2", 0, 0, 255)
+gen.add("HSV_min_blueH3", int_t, 0, "HSV_min_blueH3", 0, 0, 255)
+gen.add("HSV_max_blueH1", int_t, 0, "HSV_max_blueH1", 0, 0, 180)
+gen.add("HSV_max_blueH2", int_t, 0, "HSV_max_blueH2", 0, 0, 255)
+gen.add("HSV_max_blueH3", int_t, 0, "HSV_max_blueH3", 0, 0, 255)
+
+gen.add("HSV_min_redX1", int_t, 0, "HSV_min_redX1", 0, 0, 180)
+gen.add("HSV_min_redX2", int_t, 0, "HSV_min_redX2", 0, 0, 255)
+gen.add("HSV_min_redX3", int_t, 0, "HSV_min_redX3", 0, 0, 255)
+gen.add("HSV_max_redX1", int_t, 0, "HSV_max_redX1", 0, 0, 180)
+gen.add("HSV_max_redX2", int_t, 0, "HSV_max_redX2", 0, 0, 255)
+gen.add("HSV_max_redX3", int_t, 0, "HSV_max_redX3", 0, 0, 255)
+
+
+exit(gen.generate(PACKAGE, "vision_dynamic", "vision_dynamic_reconfigure")) 
+#first parameter is namespace's name
+#second parameter is node's name
+#third parameter is the current file's name

--- a/src/controller/Action.cpp
+++ b/src/controller/Action.cpp
@@ -4,6 +4,8 @@
 
 #include "Action.h"
 
+using namespace vwpp;
+
 
 ActionBase::ActionBase() :
         action_id(TRACKINGLINE)
@@ -34,7 +36,8 @@ ActionID ActionTrackingLine::getActionID()
 }
 
 
-DroneVelocity ActionTrackingLine::calculateVelocity(double_t _cur_line_v_y, double_t _cur_v_yaw, double_t _forward_vel)
+TargetVelXYPosZYaw
+ActionTrackingLine::calculateVelocity(double_t _cur_line_v_y, double_t _cur_v_yaw, double_t _forward_vel)
 {
     // v means data from vision, p means data from px4.
 
@@ -45,30 +48,22 @@ DroneVelocity ActionTrackingLine::calculateVelocity(double_t _cur_line_v_y, doub
                                     vwpp::DynamicRecfgInterface::getInstance()->isPidVV2PYHasThreshold(),
                                     vwpp::DynamicRecfgInterface::getInstance()->getPidVV2PYThreshold());
 
-    static vwpp::PIDController
-            pid_controller_p_local_z(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZKp(),
-                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZKi(),
-                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZKd(),
-                                     vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PZHasThreshold(),
-                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZThreshold());
 
-    static vwpp::PIDController
-            pid_controller_v_body_yaw(vwpp::DynamicRecfgInterface::getInstance()->getPidVV2PYawKp(),
-                                      vwpp::DynamicRecfgInterface::getInstance()->getPidVV2PYawKi(),
-                                      vwpp::DynamicRecfgInterface::getInstance()->getPidVV2PYawKd(),
-                                      vwpp::DynamicRecfgInterface::getInstance()->isPidVV2PYawHasThreshold(),
-                                      vwpp::DynamicRecfgInterface::getInstance()->getPidVV2PYawThreshold());
+    // TODO
+    // static vwpp::PIDController
+    //         pid_controller_v_body_yaw(vwpp::DynamicRecfgInterface::getInstance()->getPidVV2PYawKp(),
+    //                                   vwpp::DynamicRecfgInterface::getInstance()->getPidVV2PYawKi(),
+    //                                   vwpp::DynamicRecfgInterface::getInstance()->getPidVV2PYawKd(),
+    //                                   vwpp::DynamicRecfgInterface::getInstance()->isPidVV2PYawHasThreshold(),
+    //                                   vwpp::DynamicRecfgInterface::getInstance()->getPidVV2PYawThreshold());
 
 
     pid_controller_v_body_y.setTarget(0.);
-    pid_controller_p_local_z.setTarget(this->target_altitude);
-    ROS_WARN("tracking line z target:%lf",this->target_altitude);
-    pid_controller_v_body_yaw.setTarget(0.);
+    // pid_controller_v_body_yaw.setTarget(0.);
 
     pid_controller_v_body_y.update(_cur_line_v_y);
-    pid_controller_p_local_z.update(vwpp::PX4Interface::getInstance()->getCurZ());
-    pid_controller_v_body_yaw.update(
-            convertCurYaw2FabsYawThetaBetweenPI(pid_controller_v_body_yaw.getTarget(), _cur_v_yaw));
+    // pid_controller_v_body_yaw.update(
+    //         convertCurYaw2FabsYawThetaBetweenPI(pid_controller_v_body_yaw.getTarget(), _cur_v_yaw));
 
 
     geometry_msgs::Vector3Stamped linear_body_vel{};
@@ -79,8 +74,6 @@ DroneVelocity ActionTrackingLine::calculateVelocity(double_t _cur_line_v_y, doub
     ROS_WARN("forward velocity: %lf", _forward_vel);
     linear_body_vel.vector.x = _forward_vel;
     linear_body_vel.vector.y = pid_controller_v_body_y.output();
-    // TODO Test z
-    // linear_body_vel.vector.z = pid_controller_p_local_z.output();
     linear_body_vel.vector.z = 0;
 
     geometry_msgs::Vector3Stamped linear_local_vel{};
@@ -94,13 +87,14 @@ DroneVelocity ActionTrackingLine::calculateVelocity(double_t _cur_line_v_y, doub
         ros::Duration(vwpp::DynamicRecfgInterface::getInstance()->getTfBreakDuration()).sleep();
     }
 
-    DroneVelocity drone_velocity{};
-    drone_velocity.x = linear_local_vel.vector.x;
-    drone_velocity.y = linear_local_vel.vector.y;
-    drone_velocity.z = pid_controller_p_local_z.output();
-    drone_velocity.yaw = pid_controller_v_body_yaw.output();
+    TargetVelXYPosZYaw target_vel_xy_pos_z_yaw{};
+    target_vel_xy_pos_z_yaw.vx = linear_local_vel.vector.x;
+    target_vel_xy_pos_z_yaw.vy = linear_local_vel.vector.y;
+    target_vel_xy_pos_z_yaw.pz = this->target_altitude;
+    // TODO Maybe
+    target_vel_xy_pos_z_yaw.yaw = (PX4Interface::getInstance()->getCurYaw() + _cur_v_yaw);
 
-    return drone_velocity;
+    return target_vel_xy_pos_z_yaw;
 }
 
 
@@ -123,7 +117,7 @@ ActionID ActionHovering::getActionId() const
 }
 
 
-DroneVelocity ActionHovering::calculateVelocity(double_t _cur_v_x, double_t _cur_v_y)
+TargetVelXYPosZYaw ActionHovering::calculateVelocity(double_t _cur_v_x, double_t _cur_v_y)
 {
 
     static vwpp::PIDController
@@ -139,33 +133,33 @@ DroneVelocity ActionHovering::calculateVelocity(double_t _cur_v_x, double_t _cur
                                     vwpp::DynamicRecfgInterface::getInstance()->getPidVV2PYKd(),
                                     vwpp::DynamicRecfgInterface::getInstance()->isPidVV2PYHasThreshold(),
                                     vwpp::DynamicRecfgInterface::getInstance()->getPidVV2PYThreshold());
-    static vwpp::PIDController
-            pid_controller_p_local_z(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZKp(),
-                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZKi(),
-                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZKd(),
-                                     vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PZHasThreshold(),
-                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZThreshold());
-
-    static vwpp::PIDController
-            pid_controller_p_local_yaw(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawKp(),
-                                       vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawKi(),
-                                       vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawKd(),
-                                       vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PYawHasThreshold(),
-                                       vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawThreshold());
+    // static vwpp::PIDController
+    //         pid_controller_p_local_z(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZKp(),
+    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZKi(),
+    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZKd(),
+    //                                  vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PZHasThreshold(),
+    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZThreshold());
+    //
+    // static vwpp::PIDController
+    //         pid_controller_p_local_yaw(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawKp(),
+    //                                    vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawKi(),
+    //                                    vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawKd(),
+    //                                    vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PYawHasThreshold(),
+    //                                    vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawThreshold());
 
 
     pid_controller_v_body_x.setTarget(0.);
     pid_controller_v_body_y.setTarget(0.);
-    pid_controller_p_local_z.setTarget(this->target_altitude);
+    // pid_controller_p_local_z.setTarget(this->target_altitude);
     // TODO
-    pid_controller_p_local_yaw.setTarget(this->target_yaw);
+    // pid_controller_p_local_yaw.setTarget(this->target_yaw);
 
 
     pid_controller_v_body_x.update(_cur_v_x);
     pid_controller_v_body_y.update(_cur_v_y);
-    pid_controller_p_local_z.update(vwpp::PX4Interface::getInstance()->getCurZ());
-    pid_controller_p_local_yaw.update(
-            convertCurYaw2FabsYawThetaBetweenPI(target_yaw, vwpp::PX4Interface::getInstance()->getCurZ()));
+    // pid_controller_p_local_z.update(vwpp::PX4Interface::getInstance()->getCurZ());
+    // pid_controller_p_local_yaw.update(
+    //         convertCurYaw2FabsYawThetaBetweenPI(target_yaw, vwpp::PX4Interface::getInstance()->getCurZ()));
 
     geometry_msgs::Vector3Stamped linear_body_vel{};
     // linear_body_vel.header.stamp = ros::Time::now();
@@ -173,7 +167,7 @@ DroneVelocity ActionHovering::calculateVelocity(double_t _cur_v_x, double_t _cur
     linear_body_vel.header.frame_id = "camera_link";
     linear_body_vel.vector.x = pid_controller_v_body_x.output();
     linear_body_vel.vector.y = pid_controller_v_body_y.output();
-    linear_body_vel.vector.z = pid_controller_p_local_z.output();
+    linear_body_vel.vector.z = 0;
 
     geometry_msgs::Vector3Stamped linear_local_vel{};
     try
@@ -186,14 +180,22 @@ DroneVelocity ActionHovering::calculateVelocity(double_t _cur_v_x, double_t _cur
         ros::Duration(vwpp::DynamicRecfgInterface::getInstance()->getTfBreakDuration()).sleep();
     }
 
-    DroneVelocity drone_velocity{};
-    drone_velocity.x = linear_local_vel.vector.x;
-    drone_velocity.y = linear_local_vel.vector.y;
-    drone_velocity.z = linear_local_vel.vector.z;
-    drone_velocity.yaw = pid_controller_p_local_yaw.output();
+    TargetVelXYPosZYaw target_vel_xy_pos_z_yaw{};
+    target_vel_xy_pos_z_yaw.vx = linear_local_vel.vector.x;
+    target_vel_xy_pos_z_yaw.vy = linear_local_vel.vector.y;
+    target_vel_xy_pos_z_yaw.pz = target_altitude;
+    target_vel_xy_pos_z_yaw.yaw = target_yaw;
 
+    return target_vel_xy_pos_z_yaw;
 
-    return drone_velocity;
+    // DroneVelocity drone_velocity{};
+    // drone_velocity.x = linear_local_vel.vector.x;
+    // drone_velocity.y = linear_local_vel.vector.y;
+    // drone_velocity.z = linear_local_vel.vector.z;
+    // drone_velocity.yaw = pid_controller_p_local_yaw.output();
+    //
+    //
+    // return drone_velocity;
 }
 
 
@@ -201,8 +203,8 @@ ActionRotating::ActionRotating(double_t _target_altitude) :
         action_id(ROTATION),
         target_altitude(_target_altitude)
 {
-    initial_p_x = vwpp::PX4Interface::getInstance()->getCurX();
-    initial_p_y = vwpp::PX4Interface::getInstance()->getCurY();
+    on_p_x = vwpp::PX4Interface::getInstance()->getCurX();
+    on_p_y = vwpp::PX4Interface::getInstance()->getCurY();
 }
 
 
@@ -216,71 +218,78 @@ ActionID ActionRotating::getActionId() const
 }
 
 
-DroneVelocity ActionRotating::calculateVelocity(double_t _target_yaw, double_t _cur_yaw)
+TargetPosXYZYaw ActionRotating::calculateVelocity(double_t _target_yaw, double_t _cur_yaw)
 {
 
-    static vwpp::PIDController
-            pid_controller_p_local_x(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PXKp(),
-                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PXKi(),
-                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PXKd(),
-                                     vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PXHasThreshold(),
-                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PXThreshold());
-
-    static vwpp::PIDController
-            pid_controller_p_local_y(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYKp(),
-                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYKi(),
-                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYKd(),
-                                     vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PYHasThreshold(),
-                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYThreshold());
-    static vwpp::PIDController
-            pid_controller_p_local_z(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZKp(),
-                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZKi(),
-                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZKd(),
-                                     vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PZHasThreshold(),
-                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZThreshold());
-
-    static vwpp::PIDController
-            pid_controller_p_local_yaw(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawKp(),
-                                       vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawKi(),
-                                       vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawKd(),
-                                       vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PYawHasThreshold(),
-                                       vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawThreshold());
-
+    // static vwpp::PIDController
+    //         pid_controller_p_local_x(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PXKp(),
+    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PXKi(),
+    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PXKd(),
+    //                                  vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PXHasThreshold(),
+    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PXThreshold());
+    //
+    // static vwpp::PIDController
+    //         pid_controller_p_local_y(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYKp(),
+    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYKi(),
+    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYKd(),
+    //                                  vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PYHasThreshold(),
+    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYThreshold());
+    // static vwpp::PIDController
+    //         pid_controller_p_local_z(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZKp(),
+    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZKi(),
+    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZKd(),
+    //                                  vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PZHasThreshold(),
+    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZThreshold());
+    //
+    // static vwpp::PIDController
+    //         pid_controller_p_local_yaw(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawKp(),
+    //                                    vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawKi(),
+    //                                    vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawKd(),
+    //                                    vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PYawHasThreshold(),
+    //                                    vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawThreshold());
+    //
     // TODO Local->Body?
-    pid_controller_p_local_x.setTarget(this->initial_p_x);
-    pid_controller_p_local_y.setTarget(this->initial_p_y);
-    pid_controller_p_local_z.setTarget(this->target_altitude);
-    ROS_ERROR("target altitude: %lf", this->target_altitude);
-    pid_controller_p_local_yaw.setTarget(_target_yaw);
+    // pid_controller_p_local_x.setTarget(this->on_p_x);
+    // pid_controller_p_local_y.setTarget(this->on_p_y);
+    // pid_controller_p_local_z.setTarget(this->target_altitude);
+    // ROS_ERROR("target altitude: %lf", this->target_altitude);
+    // pid_controller_p_local_yaw.setTarget(_target_yaw);
+    //
+    // pid_controller_p_local_x.update(vwpp::PX4Interface::getInstance()->getCurX());
+    // pid_controller_p_local_y.update(vwpp::PX4Interface::getInstance()->getCurY());
+    // pid_controller_p_local_z.update(vwpp::PX4Interface::getInstance()->getCurZ());
+    // pid_controller_p_local_yaw.update(convertCurYaw2FabsYawThetaBetweenPI(_target_yaw, _cur_yaw));
+    //
+    // DroneVelocity drone_velocity{};
+    // drone_velocity.x = pid_controller_p_local_x.output();
+    // drone_velocity.y = pid_controller_p_local_y.output();
+    // drone_velocity.z = pid_controller_p_local_z.output();
+    // drone_velocity.yaw = pid_controller_p_local_yaw.output();
+    //
+    // return drone_velocity;
+    TargetPosXYZYaw target_pose_xyz_yaw{};
+    target_pose_xyz_yaw.px = on_p_x;
+    target_pose_xyz_yaw.py = on_p_y;
+    target_pose_xyz_yaw.pz = target_altitude;
+    target_pose_xyz_yaw.yaw = _target_yaw;
 
-    pid_controller_p_local_x.update(vwpp::PX4Interface::getInstance()->getCurX());
-    pid_controller_p_local_y.update(vwpp::PX4Interface::getInstance()->getCurY());
-    pid_controller_p_local_z.update(vwpp::PX4Interface::getInstance()->getCurZ());
-    pid_controller_p_local_yaw.update(convertCurYaw2FabsYawThetaBetweenPI(_target_yaw, _cur_yaw));
-
-    DroneVelocity drone_velocity{};
-    drone_velocity.x = pid_controller_p_local_x.output();
-    drone_velocity.y = pid_controller_p_local_y.output();
-    drone_velocity.z = pid_controller_p_local_z.output();
-    drone_velocity.yaw = pid_controller_p_local_yaw.output();
-
-    return drone_velocity;
+    return target_pose_xyz_yaw;
 }
 
 
-int8_t ActionRotating::setHoverOnXY(double_t _hover_x, double_t _hover_y)
+int8_t ActionRotating::setRotatingOnXY(double_t _hover_x, double_t _hover_y)
 {
-    initial_p_x = _hover_x;
-    initial_p_y = _hover_y;
+    on_p_x = _hover_x;
+    on_p_y = _hover_y;
 }
 
 
 ActionAdjustAltitude::ActionAdjustAltitude() :
         action_id(ADJUSTALTITUDE)
 {
-    initial_p_x = vwpp::PX4Interface::getInstance()->getCurX();
-    initial_p_y = vwpp::PX4Interface::getInstance()->getCurY();
-    initial_p_yaw = vwpp::PX4Interface::getInstance()->getCurYaw();
+    on_p_x = vwpp::PX4Interface::getInstance()->getCurX();
+    on_p_y = vwpp::PX4Interface::getInstance()->getCurY();
+    on_p_yaw = vwpp::PX4Interface::getInstance()->getCurYaw();
 }
 
 
@@ -294,54 +303,72 @@ ActionID ActionAdjustAltitude::getActionId() const
 }
 
 
-DroneVelocity ActionAdjustAltitude::calculateVelocity(double_t _target_altitude, double_t _cur_altitude)
+TargetPosXYZYaw ActionAdjustAltitude::calculateVelocity(double_t _target_altitude, double_t _cur_altitude)
 {
-    static vwpp::PIDController
-            pid_controller_p_local_x(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PXKp(),
-                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PXKi(),
-                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PXKd(),
-                                     vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PXHasThreshold(),
-                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PXThreshold());
+    // static vwpp::PIDController
+    //         pid_controller_p_local_x(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PXKp(),
+    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PXKi(),
+    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PXKd(),
+    //                                  vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PXHasThreshold(),
+    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PXThreshold());
+    //
+    // static vwpp::PIDController
+    //         pid_controller_p_local_y(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYKp(),
+    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYKi(),
+    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYKd(),
+    //                                  vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PYHasThreshold(),
+    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYThreshold());
+    //
+    // static vwpp::PIDController
+    //         pid_controller_p_local_z(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZKp(),
+    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZKi(),
+    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZKd(),
+    //                                  vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PZHasThreshold(),
+    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZThreshold());
 
-    static vwpp::PIDController
-            pid_controller_p_local_y(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYKp(),
-                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYKi(),
-                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYKd(),
-                                     vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PYHasThreshold(),
-                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYThreshold());
+    // static vwpp::PIDController
+    //         pid_controller_p_local_yaw(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawKp(),
+    //                                    vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawKi(),
+    //                                    vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawKd(),
+    //                                    vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PYawHasThreshold(),
+    //                                    vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawThreshold());
 
-    static vwpp::PIDController
-            pid_controller_p_local_z(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZKp(),
-                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZKi(),
-                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZKd(),
-                                     vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PZHasThreshold(),
-                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZThreshold());
+    // pid_controller_p_local_x.setTarget(this->on_p_x);
+    // pid_controller_p_local_y.setTarget(this->on_p_y);
+    // pid_controller_p_local_z.setTarget(_target_altitude);
+    // pid_controller_p_local_yaw.setTarget(this->on_p_yaw);
 
-    static vwpp::PIDController
-            pid_controller_p_local_yaw(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawKp(),
-                                       vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawKi(),
-                                       vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawKd(),
-                                       vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PYawHasThreshold(),
-                                       vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawThreshold());
+    // pid_controller_p_local_x.update(vwpp::PX4Interface::getInstance()->getCurX());
+    // pid_controller_p_local_y.update(vwpp::PX4Interface::getInstance()->getCurY());
+    // pid_controller_p_local_z.update(vwpp::PX4Interface::getInstance()->getCurZ());
+    // pid_controller_p_local_yaw.update(
+    //         convertCurYaw2FabsYawThetaBetweenPI(on_p_yaw, vwpp::PX4Interface::getInstance()->getCurYaw()));
 
-    pid_controller_p_local_x.setTarget(this->initial_p_x);
-    pid_controller_p_local_y.setTarget(this->initial_p_y);
-    pid_controller_p_local_z.setTarget(_target_altitude);
-    pid_controller_p_local_yaw.setTarget(this->initial_p_yaw);
+    // DroneVelocity drone_velocity{};
+    // drone_velocity.x = pid_controller_p_local_x.output();
+    // drone_velocity.y = pid_controller_p_local_y.output();
+    // drone_velocity.z = pid_controller_p_local_z.output();
+    // drone_velocity.yaw = pid_controller_p_local_yaw.output();
+    //
+    // return drone_velocity;
 
-    pid_controller_p_local_x.update(vwpp::PX4Interface::getInstance()->getCurX());
-    pid_controller_p_local_y.update(vwpp::PX4Interface::getInstance()->getCurY());
-    pid_controller_p_local_z.update(vwpp::PX4Interface::getInstance()->getCurZ());
-    pid_controller_p_local_yaw.update(
-            convertCurYaw2FabsYawThetaBetweenPI(initial_p_yaw, vwpp::PX4Interface::getInstance()->getCurYaw()));
+    TargetPosXYZYaw target_pos_xyz_yaw{};
+    target_pos_xyz_yaw.px = on_p_x;
+    target_pos_xyz_yaw.py = on_p_y;
+    target_pos_xyz_yaw.pz = _target_altitude;
+    target_pos_xyz_yaw.yaw = on_p_yaw;
 
-    DroneVelocity drone_velocity{};
-    drone_velocity.x = pid_controller_p_local_x.output();
-    drone_velocity.y = pid_controller_p_local_y.output();
-    drone_velocity.z = pid_controller_p_local_z.output();
-    drone_velocity.yaw = pid_controller_p_local_yaw.output();
+    return target_pos_xyz_yaw;
+}
 
-    return drone_velocity;
+
+int8_t ActionAdjustAltitude::setAdjustAltitudeXYYaw(double_t _on_x, double_t _on_y, double_t _on_yaw)
+{
+    on_p_x = _on_x;
+    on_p_y = _on_y;
+    on_p_yaw = _on_yaw;
+
+    return 0;
 }
 
 

--- a/src/controller/Action.cpp
+++ b/src/controller/Action.cpp
@@ -48,28 +48,11 @@ ActionTrackingLine::calculateVelocity(double_t _cur_line_v_y, double_t _cur_v_ya
                                     vwpp::DynamicRecfgInterface::getInstance()->isPidVV2PYHasThreshold(),
                                     vwpp::DynamicRecfgInterface::getInstance()->getPidVV2PYThreshold());
 
-
-    // TODO
-    // static vwpp::PIDController
-    //         pid_controller_v_body_yaw(vwpp::DynamicRecfgInterface::getInstance()->getPidVV2PYawKp(),
-    //                                   vwpp::DynamicRecfgInterface::getInstance()->getPidVV2PYawKi(),
-    //                                   vwpp::DynamicRecfgInterface::getInstance()->getPidVV2PYawKd(),
-    //                                   vwpp::DynamicRecfgInterface::getInstance()->isPidVV2PYawHasThreshold(),
-    //                                   vwpp::DynamicRecfgInterface::getInstance()->getPidVV2PYawThreshold());
-
-
     pid_controller_v_body_y.setTarget(0.);
-    // pid_controller_v_body_yaw.setTarget(0.);
-
     pid_controller_v_body_y.update(_cur_line_v_y);
-    // pid_controller_v_body_yaw.update(
-    //         convertCurYaw2FabsYawThetaBetweenPI(pid_controller_v_body_yaw.getTarget(), _cur_v_yaw));
-
 
     geometry_msgs::Vector3Stamped linear_body_vel{};
-    // linear_body_vel.header.stamp = ros::Time::now();
     linear_body_vel.header.stamp = ros::Time(0);
-    // TODO param
     linear_body_vel.header.frame_id = "camera_link";
     ROS_WARN("forward velocity: %lf", _forward_vel);
     linear_body_vel.vector.x = _forward_vel;
@@ -91,7 +74,6 @@ ActionTrackingLine::calculateVelocity(double_t _cur_line_v_y, double_t _cur_v_ya
     target_vel_xy_pos_z_yaw.vx = linear_local_vel.vector.x;
     target_vel_xy_pos_z_yaw.vy = linear_local_vel.vector.y;
     target_vel_xy_pos_z_yaw.pz = this->target_altitude;
-    // TODO Maybe
     target_vel_xy_pos_z_yaw.yaw = (PX4Interface::getInstance()->getCurYaw() - _cur_v_yaw);
 
     return target_vel_xy_pos_z_yaw;
@@ -218,55 +200,60 @@ ActionID ActionRotating::getActionId() const
 }
 
 
-TargetPosXYZYaw ActionRotating::calculateVelocity(double_t _target_yaw, double_t _cur_yaw)
+DroneVelocity ActionRotating::calculateVelocity(double_t _target_yaw, double_t _cur_yaw)
 {
 
-    // static vwpp::PIDController
-    //         pid_controller_p_local_x(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PXKp(),
-    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PXKi(),
-    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PXKd(),
-    //                                  vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PXHasThreshold(),
-    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PXThreshold());
-    //
-    // static vwpp::PIDController
-    //         pid_controller_p_local_y(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYKp(),
-    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYKi(),
-    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYKd(),
-    //                                  vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PYHasThreshold(),
-    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYThreshold());
-    // static vwpp::PIDController
-    //         pid_controller_p_local_z(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZKp(),
-    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZKi(),
-    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZKd(),
-    //                                  vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PZHasThreshold(),
-    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZThreshold());
-    //
-    // static vwpp::PIDController
-    //         pid_controller_p_local_yaw(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawKp(),
-    //                                    vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawKi(),
-    //                                    vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawKd(),
-    //                                    vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PYawHasThreshold(),
-    //                                    vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawThreshold());
-    //
+    static vwpp::PIDController
+            pid_controller_p_local_x(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PXKp(),
+                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PXKi(),
+                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PXKd(),
+                                     vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PXHasThreshold(),
+                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PXThreshold());
+
+    static vwpp::PIDController
+            pid_controller_p_local_y(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYKp(),
+                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYKi(),
+                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYKd(),
+                                     vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PYHasThreshold(),
+                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYThreshold());
+    static vwpp::PIDController
+            pid_controller_p_local_z(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZKp(),
+                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZKi(),
+                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZKd(),
+                                     vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PZHasThreshold(),
+                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZThreshold());
+
+    static vwpp::PIDController
+            pid_controller_p_local_yaw(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawKp(),
+                                       vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawKi(),
+                                       vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawKd(),
+                                       vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PYawHasThreshold(),
+                                       vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawThreshold());
+
     // TODO Local->Body?
-    // pid_controller_p_local_x.setTarget(this->on_p_x);
-    // pid_controller_p_local_y.setTarget(this->on_p_y);
-    // pid_controller_p_local_z.setTarget(this->target_altitude);
-    // ROS_ERROR("target altitude: %lf", this->target_altitude);
-    // pid_controller_p_local_yaw.setTarget(_target_yaw);
-    //
-    // pid_controller_p_local_x.update(vwpp::PX4Interface::getInstance()->getCurX());
-    // pid_controller_p_local_y.update(vwpp::PX4Interface::getInstance()->getCurY());
-    // pid_controller_p_local_z.update(vwpp::PX4Interface::getInstance()->getCurZ());
-    // pid_controller_p_local_yaw.update(convertCurYaw2FabsYawThetaBetweenPI(_target_yaw, _cur_yaw));
-    //
-    // DroneVelocity drone_velocity{};
-    // drone_velocity.x = pid_controller_p_local_x.output();
-    // drone_velocity.y = pid_controller_p_local_y.output();
-    // drone_velocity.z = pid_controller_p_local_z.output();
-    // drone_velocity.yaw = pid_controller_p_local_yaw.output();
-    //
-    // return drone_velocity;
+    pid_controller_p_local_x.setTarget(this->on_p_x);
+    pid_controller_p_local_y.setTarget(this->on_p_y);
+    pid_controller_p_local_z.setTarget(this->target_altitude);
+    ROS_ERROR("target altitude: %lf", this->target_altitude);
+    pid_controller_p_local_yaw.setTarget(_target_yaw);
+
+    pid_controller_p_local_x.update(vwpp::PX4Interface::getInstance()->getCurX());
+    pid_controller_p_local_y.update(vwpp::PX4Interface::getInstance()->getCurY());
+    pid_controller_p_local_z.update(vwpp::PX4Interface::getInstance()->getCurZ());
+    pid_controller_p_local_yaw.update(convertCurYaw2FabsYawThetaBetweenPI(_target_yaw, _cur_yaw));
+
+    DroneVelocity drone_velocity{};
+    drone_velocity.x = pid_controller_p_local_x.output();
+    drone_velocity.y = pid_controller_p_local_y.output();
+    drone_velocity.z = pid_controller_p_local_z.output();
+    drone_velocity.yaw = pid_controller_p_local_yaw.output();
+
+    return drone_velocity;
+}
+
+
+TargetPosXYZYaw ActionRotating::calculateVelocity(double_t _target_yaw)
+{
     TargetPosXYZYaw target_pose_xyz_yaw{};
     target_pose_xyz_yaw.px = on_p_x;
     target_pose_xyz_yaw.py = on_p_y;
@@ -301,6 +288,7 @@ ActionID ActionAdjustAltitude::getActionId() const
 {
     return action_id;
 }
+
 
 DroneVelocity ActionAdjustAltitude::calculateVelocity(double_t _target_altitude, double_t _cur_altitude)
 {
@@ -352,6 +340,7 @@ DroneVelocity ActionAdjustAltitude::calculateVelocity(double_t _target_altitude,
     return drone_velocity;
 
 }
+
 
 TargetPosXYZYaw ActionAdjustAltitude::calculateVelocity(double_t _target_altitude)
 {

--- a/src/controller/Action.cpp
+++ b/src/controller/Action.cpp
@@ -92,7 +92,7 @@ ActionTrackingLine::calculateVelocity(double_t _cur_line_v_y, double_t _cur_v_ya
     target_vel_xy_pos_z_yaw.vy = linear_local_vel.vector.y;
     target_vel_xy_pos_z_yaw.pz = this->target_altitude;
     // TODO Maybe
-    target_vel_xy_pos_z_yaw.yaw = (PX4Interface::getInstance()->getCurYaw() + _cur_v_yaw);
+    target_vel_xy_pos_z_yaw.yaw = (PX4Interface::getInstance()->getCurYaw() - _cur_v_yaw);
 
     return target_vel_xy_pos_z_yaw;
 }
@@ -277,7 +277,7 @@ TargetPosXYZYaw ActionRotating::calculateVelocity(double_t _target_yaw, double_t
 }
 
 
-int8_t ActionRotating::setRotatingOnXY(double_t _hover_x, double_t _hover_y)
+int8_t ActionRotating::resetRotatingOnXY(double_t _hover_x, double_t _hover_y)
 {
     on_p_x = _hover_x;
     on_p_y = _hover_y;
@@ -302,56 +302,59 @@ ActionID ActionAdjustAltitude::getActionId() const
     return action_id;
 }
 
-
-TargetPosXYZYaw ActionAdjustAltitude::calculateVelocity(double_t _target_altitude, double_t _cur_altitude)
+DroneVelocity ActionAdjustAltitude::calculateVelocity(double_t _target_altitude, double_t _cur_altitude)
 {
-    // static vwpp::PIDController
-    //         pid_controller_p_local_x(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PXKp(),
-    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PXKi(),
-    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PXKd(),
-    //                                  vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PXHasThreshold(),
-    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PXThreshold());
-    //
-    // static vwpp::PIDController
-    //         pid_controller_p_local_y(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYKp(),
-    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYKi(),
-    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYKd(),
-    //                                  vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PYHasThreshold(),
-    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYThreshold());
-    //
-    // static vwpp::PIDController
-    //         pid_controller_p_local_z(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZKp(),
-    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZKi(),
-    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZKd(),
-    //                                  vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PZHasThreshold(),
-    //                                  vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZThreshold());
+    static vwpp::PIDController
+            pid_controller_p_local_x(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PXKp(),
+                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PXKi(),
+                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PXKd(),
+                                     vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PXHasThreshold(),
+                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PXThreshold());
 
-    // static vwpp::PIDController
-    //         pid_controller_p_local_yaw(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawKp(),
-    //                                    vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawKi(),
-    //                                    vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawKd(),
-    //                                    vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PYawHasThreshold(),
-    //                                    vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawThreshold());
+    static vwpp::PIDController
+            pid_controller_p_local_y(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYKp(),
+                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYKi(),
+                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYKd(),
+                                     vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PYHasThreshold(),
+                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYThreshold());
 
-    // pid_controller_p_local_x.setTarget(this->on_p_x);
-    // pid_controller_p_local_y.setTarget(this->on_p_y);
-    // pid_controller_p_local_z.setTarget(_target_altitude);
-    // pid_controller_p_local_yaw.setTarget(this->on_p_yaw);
+    static vwpp::PIDController
+            pid_controller_p_local_z(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZKp(),
+                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZKi(),
+                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZKd(),
+                                     vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PZHasThreshold(),
+                                     vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PZThreshold());
 
-    // pid_controller_p_local_x.update(vwpp::PX4Interface::getInstance()->getCurX());
-    // pid_controller_p_local_y.update(vwpp::PX4Interface::getInstance()->getCurY());
-    // pid_controller_p_local_z.update(vwpp::PX4Interface::getInstance()->getCurZ());
-    // pid_controller_p_local_yaw.update(
-    //         convertCurYaw2FabsYawThetaBetweenPI(on_p_yaw, vwpp::PX4Interface::getInstance()->getCurYaw()));
+    static vwpp::PIDController
+            pid_controller_p_local_yaw(vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawKp(),
+                                       vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawKi(),
+                                       vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawKd(),
+                                       vwpp::DynamicRecfgInterface::getInstance()->isPidPV2PYawHasThreshold(),
+                                       vwpp::DynamicRecfgInterface::getInstance()->getPidPV2PYawThreshold());
 
-    // DroneVelocity drone_velocity{};
-    // drone_velocity.x = pid_controller_p_local_x.output();
-    // drone_velocity.y = pid_controller_p_local_y.output();
-    // drone_velocity.z = pid_controller_p_local_z.output();
-    // drone_velocity.yaw = pid_controller_p_local_yaw.output();
-    //
-    // return drone_velocity;
+    pid_controller_p_local_x.setTarget(this->on_p_x);
+    pid_controller_p_local_y.setTarget(this->on_p_y);
+    pid_controller_p_local_z.setTarget(_target_altitude);
+    pid_controller_p_local_yaw.setTarget(this->on_p_yaw);
 
+    pid_controller_p_local_x.update(vwpp::PX4Interface::getInstance()->getCurX());
+    pid_controller_p_local_y.update(vwpp::PX4Interface::getInstance()->getCurY());
+    pid_controller_p_local_z.update(_cur_altitude);
+    pid_controller_p_local_yaw.update(
+            convertCurYaw2FabsYawThetaBetweenPI(on_p_yaw, vwpp::PX4Interface::getInstance()->getCurYaw()));
+
+    DroneVelocity drone_velocity{};
+    drone_velocity.x = pid_controller_p_local_x.output();
+    drone_velocity.y = pid_controller_p_local_y.output();
+    drone_velocity.z = pid_controller_p_local_z.output();
+    drone_velocity.yaw = pid_controller_p_local_yaw.output();
+
+    return drone_velocity;
+
+}
+
+TargetPosXYZYaw ActionAdjustAltitude::calculateVelocity(double_t _target_altitude)
+{
     TargetPosXYZYaw target_pos_xyz_yaw{};
     target_pos_xyz_yaw.px = on_p_x;
     target_pos_xyz_yaw.py = on_p_y;
@@ -370,5 +373,7 @@ int8_t ActionAdjustAltitude::setAdjustAltitudeXYYaw(double_t _on_x, double_t _on
 
     return 0;
 }
+
+
 
 

--- a/src/controller/Action.h
+++ b/src/controller/Action.h
@@ -13,131 +13,138 @@
 #include "controller/PIDController.h"
 #include "utils/utils.h"
 
-
-enum ActionID
+namespace vwpp
 {
-    TRACKINGLINE = 0,
-    ADJUSTALTITUDE,
-    HOVERING,
-    ROTATION,
-    OPENCLAW,
-    CIRCULARMOTION  //TODO
-};
-
-struct DroneVelocity
-{
-    double_t x;
-    double_t y;
-    double_t z;
-    double_t yaw;
-};
 
 
-class ActionBase
-{
-public:
-    ActionBase();
+    enum ActionID
+    {
+        TRACKINGLINE = 0,
+        ADJUSTALTITUDE,
+        HOVERING,
+        ROTATION,
+        OPENCLAW,
+        CIRCULARMOTION  //TODO
+    };
 
-    virtual ~ActionBase();
-
-    ActionID action_id;
-
-private:
-
-};
-
-class ActionTrackingLine
-{
-public:
-
-    explicit ActionTrackingLine(double_t _target_altitude);
-
-    virtual ~ActionTrackingLine();
-
-    ActionID getActionID();
-
-    DroneVelocity calculateVelocity(double_t _cur_line_v_y, double_t _cur_v_yaw,
-                                    double_t _forward_vel = vwpp::DynamicRecfgInterface::getInstance()->getForwardVel());
-
-private:
-
-    double_t target_altitude;
-
-    // TODO ptr
-    tf::TransformListener odom_base_tf_listener;
-
-    ActionID action_id;
-};
+    struct DroneVelocity
+    {
+        double_t x;
+        double_t y;
+        double_t z;
+        double_t yaw;
+    };
 
 
-class ActionAdjustAltitude
-{
-public:
+    class ActionBase
+    {
+    public:
+        ActionBase();
 
-    ActionAdjustAltitude();
+        virtual ~ActionBase();
 
-    virtual ~ActionAdjustAltitude();
+        ActionID action_id;
 
-    ActionID getActionId() const;
+    private:
 
-    DroneVelocity calculateVelocity(double_t _target_altitude, double_t _cur_altitude);
+    };
 
-private:
+    class ActionTrackingLine
+    {
+    public:
 
-    double_t initial_p_x;
-    double_t initial_p_y;
-    double_t initial_p_yaw;
+        explicit ActionTrackingLine(double_t _target_altitude);
 
-    ActionID action_id;
+        virtual ~ActionTrackingLine();
 
-};
+        ActionID getActionID();
+
+        TargetVelXYPosZYaw calculateVelocity(double_t _cur_line_v_y, double_t _cur_v_yaw,
+                                        double_t _forward_vel = vwpp::DynamicRecfgInterface::getInstance()->getForwardVel());
 
 
-class ActionHovering
-{
-public:
 
-    explicit ActionHovering(double_t _target_altitude);
+    private:
 
-    virtual ~ActionHovering();
+        double_t target_altitude;
 
-    ActionID getActionId() const;
+        // TODO ptr
+        tf::TransformListener odom_base_tf_listener;
 
-    DroneVelocity calculateVelocity(double_t _cur_v_x, double_t _cur_v_y);
+        ActionID action_id;
+    };
 
-private:
 
-    double_t target_altitude;
-    double_t target_yaw;
+    class ActionAdjustAltitude
+    {
+    public:
 
-    tf::TransformListener odom_base_tf_listener;
+        ActionAdjustAltitude();
 
-    ActionID action_id;
-};
+        virtual ~ActionAdjustAltitude();
 
-class ActionRotating
-{
-public:
+        ActionID getActionId() const;
 
-    explicit ActionRotating(double_t _target_altitude);
+        TargetPosXYZYaw calculateVelocity(double_t _target_altitude, double_t _cur_altitude);
 
-    virtual ~ActionRotating();
+        int8_t setAdjustAltitudeXYYaw(double_t _on_x, double_t _on_y, double_t _on_yaw);
 
-    ActionID getActionId() const;
+    private:
 
-    DroneVelocity calculateVelocity(double_t _target_yaw, double_t _cur_yaw);
+        double_t on_p_x;
+        double_t on_p_y;
+        double_t on_p_yaw;
 
-    int8_t setHoverOnXY(double_t _hover_x, double_t _hover_y);
+        ActionID action_id;
 
-private:
+    };
 
-    double_t target_altitude;
 
-    // TODO Add to Constructor?
-    double_t initial_p_x;
-    double_t initial_p_y;
+    class ActionHovering
+    {
+    public:
 
-    ActionID action_id;
-};
+        explicit ActionHovering(double_t _target_altitude);
+
+        virtual ~ActionHovering();
+
+        ActionID getActionId() const;
+
+        TargetVelXYPosZYaw calculateVelocity(double_t _cur_v_x, double_t _cur_v_y);
+
+    private:
+
+        double_t target_altitude;
+        double_t target_yaw;
+
+        tf::TransformListener odom_base_tf_listener;
+
+        ActionID action_id;
+    };
+
+    class ActionRotating
+    {
+    public:
+
+        explicit ActionRotating(double_t _target_altitude);
+
+        virtual ~ActionRotating();
+
+        ActionID getActionId() const;
+
+        TargetPosXYZYaw calculateVelocity(double_t _target_yaw, double_t _cur_yaw);
+
+        int8_t setRotatingOnXY(double_t _hover_x, double_t _hover_y);
+
+    private:
+
+        double_t target_altitude;
+
+        double_t on_p_x;
+        double_t on_p_y;
+
+        ActionID action_id;
+    };
+}
 
 #endif //FIRA_ESI_ACTION_H_

--- a/src/controller/Action.h
+++ b/src/controller/Action.h
@@ -85,7 +85,8 @@ namespace vwpp
 
         ActionID getActionId() const;
 
-        TargetPosXYZYaw calculateVelocity(double_t _target_altitude, double_t _cur_altitude);
+        TargetPosXYZYaw calculateVelocity(double_t _target_altitude);
+        DroneVelocity calculateVelocity(double_t _target_altitude, double_t _cur_altitude);
 
         int8_t setAdjustAltitudeXYYaw(double_t _on_x, double_t _on_y, double_t _on_yaw);
 
@@ -134,7 +135,7 @@ namespace vwpp
 
         TargetPosXYZYaw calculateVelocity(double_t _target_yaw, double_t _cur_yaw);
 
-        int8_t setRotatingOnXY(double_t _hover_x, double_t _hover_y);
+        int8_t resetRotatingOnXY(double_t _hover_x, double_t _hover_y);
 
     private:
 

--- a/src/controller/Action.h
+++ b/src/controller/Action.h
@@ -133,7 +133,8 @@ namespace vwpp
 
         ActionID getActionId() const;
 
-        TargetPosXYZYaw calculateVelocity(double_t _target_yaw, double_t _cur_yaw);
+        TargetPosXYZYaw calculateVelocity(double_t _target_yaw);
+        DroneVelocity calculateVelocity(double_t _target_yaw, double_t _cur_yaw);
 
         int8_t resetRotatingOnXY(double_t _hover_x, double_t _hover_y);
 

--- a/src/controller/FlowController.cpp
+++ b/src/controller/FlowController.cpp
@@ -71,6 +71,7 @@ int8_t vwpp::FlowController::run()
 
 
             // Switch to HoverOnQR
+            ROS_ERROR("Navigation finished!");
             if (VisionInterface::getInstance()->getGroundQRState())
             {
                 p_task_navigation->restart();

--- a/src/controller/FlowController.cpp
+++ b/src/controller/FlowController.cpp
@@ -56,18 +56,24 @@ int8_t vwpp::FlowController::run()
         {
 
             // Switch to Avoidance
-            // if (VisionInterface::getInstance()->getYellowGateState())
-            // {
-            //     gate_type = YELLOW;
-            //     cur_task_id = AVOIDANCE;
-            //     ROS_INFO("Task switch to AVOIDANCE!");
-            // }
-            // else if (VisionInterface::getInstance()->getRedGateState())
-            // {
-            //     gate_type = RED;
-            //     cur_task_id = AVOIDANCE;
-            //     ROS_INFO("Task switch to AVOIDANCE!");
-            // }
+            if (VisionInterface::getInstance()->getYellowGateState())
+            {
+                gate_type = YELLOW;
+                cur_task_id = AVOIDANCE;
+                p_task_avoidance->resetAdjustAltitudeOnXYYaw(PX4Interface::getInstance()->getCurX(),
+                                                             PX4Interface::getInstance()->getCurY(),
+                                                             PX4Interface::getInstance()->getCurYaw());
+                ROS_INFO("Task switch to AVOIDANCE!");
+            }
+            else if (VisionInterface::getInstance()->getRedGateState())
+            {
+                gate_type = RED;
+                cur_task_id = AVOIDANCE;
+                p_task_avoidance->resetAdjustAltitudeOnXYYaw(PX4Interface::getInstance()->getCurX(),
+                                                             PX4Interface::getInstance()->getCurY(),
+                                                             PX4Interface::getInstance()->getCurYaw());
+                ROS_INFO("Task switch to AVOIDANCE!");
+            }
 
 
             // Switch to HoverOnQR

--- a/src/controller/FlowController.cpp
+++ b/src/controller/FlowController.cpp
@@ -75,7 +75,8 @@ int8_t vwpp::FlowController::run()
             {
                 p_task_navigation->restart();
                 cur_task_id = HOVERONQR;
-                p_task_hover_on_qr->resetHoverOnXY(PX4Interface::getInstance()->getCurX(), PX4Interface::getInstance()->getCurY());
+                p_task_hover_on_qr->resetRotatingOnXY(PX4Interface::getInstance()->getCurX(),
+                                                      PX4Interface::getInstance()->getCurY());
                 // cur_task_id = LANDING;
                 ROS_INFO("Task switch to HOVERONQR!");
             }

--- a/src/controller/Task.cpp
+++ b/src/controller/Task.cpp
@@ -74,18 +74,13 @@ int8_t vwpp::TaskNavigation::run()
         static ActionTrackingLine action_tracking_line(
                 vwpp::DynamicRecfgInterface::getInstance()->getNormalFlightAltitude());
 
-        DroneVelocity drone_velocity =
+        TargetVelXYPosZYaw target_vel_xy_pos_z_yaw =
                 action_tracking_line.calculateVelocity(
                         vwpp::VisionInterface::getInstance()->getLineOffset(),
-                        vwpp::VisionInterface::getInstance()->getLineRotation());
+                        vwpp::VisionInterface::getInstance()->getLineRotation()
+                );
 
-        geometry_msgs::Twist cmd_vel;
-        cmd_vel.linear.x = drone_velocity.x;
-        cmd_vel.linear.y = drone_velocity.y;
-        cmd_vel.linear.z = drone_velocity.z;
-        cmd_vel.angular.z = drone_velocity.yaw;
-
-        PX4Interface::getInstance()->publishLocalVel(cmd_vel);
+        PX4Interface::getInstance()->publishTarget(target_vel_xy_pos_z_yaw);
     }
 
     return 0;
@@ -138,7 +133,7 @@ int8_t vwpp::TaskAvoidance::run(GateType _gate_type)
     // VisionInterface::getInstance()->update();
     // PX4Interface::getInstance()->update();
 
-    geometry_msgs::Twist cmd_vel;
+    // geometry_msgs::Twist cmd_vel;
     static int inter_adjust_altitude_time = 1;
 
     if (cur_action_id == ADJUSTALTITUDE)
@@ -159,15 +154,17 @@ int8_t vwpp::TaskAvoidance::run(GateType _gate_type)
             }
 
 
+            // TODO initial_x, y
             // TODO ptr
             static ActionAdjustAltitude action_adjust_altitude;
-            DroneVelocity drone_velocity = action_adjust_altitude.calculateVelocity(this->altitude_target,
-                                                                                    PX4Interface::getInstance()->getCurZ());
+            TargetPosXYZYaw target_pos_xyz_yaw = action_adjust_altitude.calculateVelocity(this->altitude_target,
+                                                                                          PX4Interface::getInstance()->getCurZ());
 
-            cmd_vel.linear.x = drone_velocity.x;
-            cmd_vel.linear.y = drone_velocity.y;
-            cmd_vel.linear.z = drone_velocity.z;
-            cmd_vel.angular.z = drone_velocity.yaw;
+            // cmd_vel.linear.x = drone_velocity.x;
+            // cmd_vel.linear.y = drone_velocity.y;
+            // cmd_vel.linear.z = drone_velocity.z;
+            // cmd_vel.angular.z = drone_velocity.yaw;
+            PX4Interface::getInstance()->publishTarget(target_pos_xyz_yaw);
 
 
             if (fabs(PX4Interface::getInstance()->getCurZ() - altitude_target) <=
@@ -188,14 +185,16 @@ int8_t vwpp::TaskAvoidance::run(GateType _gate_type)
                     vwpp::DynamicRecfgInterface::getInstance()->getNormalFlightAltitude();
 
 
+            // TODO initial_x, y
             static ActionAdjustAltitude action_adjust_altitude;
-            DroneVelocity drone_velocity = action_adjust_altitude.calculateVelocity(this->altitude_target,
-                                                                                    PX4Interface::getInstance()->getCurZ());
+            TargetPosXYZYaw target_pos_xyz_yaw = action_adjust_altitude.calculateVelocity(this->altitude_target,
+                                                                                          PX4Interface::getInstance()->getCurZ());
 
-            cmd_vel.linear.x = drone_velocity.x;
-            cmd_vel.linear.y = drone_velocity.y;
-            cmd_vel.linear.z = drone_velocity.z;
-            cmd_vel.angular.z = drone_velocity.yaw;
+            // cmd_vel.linear.x = drone_velocity.x;
+            // cmd_vel.linear.y = drone_velocity.y;
+            // cmd_vel.linear.z = drone_velocity.z;
+            // cmd_vel.angular.z = drone_velocity.yaw;
+            PX4Interface::getInstance()->publishTarget(target_pos_xyz_yaw);
 
 
             if (fabs(PX4Interface::getInstance()->getCurZ() - altitude_target) <=
@@ -228,20 +227,21 @@ int8_t vwpp::TaskAvoidance::run(GateType _gate_type)
         }
 
         static ActionTrackingLine action_tracking_line(this->altitude_target);
-        DroneVelocity drone_velocity =
+        TargetVelXYPosZYaw target_vel_xy_pos_z_yaw =
                 action_tracking_line.calculateVelocity(
                         vwpp::VisionInterface::getInstance()->getLineOffset(),
                         vwpp::VisionInterface::getInstance()->getLineRotation());
 
 
-        cmd_vel.linear.x = drone_velocity.x;
-        cmd_vel.linear.y = drone_velocity.y;
-        cmd_vel.linear.z = drone_velocity.z;
-        cmd_vel.angular.z = drone_velocity.yaw;
+        PX4Interface::getInstance()->publishTarget(target_vel_xy_pos_z_yaw);
+        // cmd_vel.linear.x = drone_velocity.x;
+        // cmd_vel.linear.y = drone_velocity.y;
+        // cmd_vel.linear.z = drone_velocity.z;
+        // cmd_vel.angular.z = drone_velocity.yaw;
 
     }
 
-    PX4Interface::getInstance()->publishLocalVel(cmd_vel);
+    // PX4Interface::getInstance()->publishSetpointVel(cmd_vel);
     p_task_base->task_state = TASK_PROCESSING;
     return 0;
 
@@ -345,7 +345,7 @@ char vwpp::TaskHoverOnQR::run(TaskID _cur_task_id, std::string _qr_inform)
         cmd_vel.linear.z = drone_velocity.z;
         cmd_vel.angular.z = drone_velocity.yaw;
 
-        PX4Interface::getInstance()->publishLocalVel(cmd_vel);
+        // PX4Interface::getInstance()->publishSetpointVel(cmd_vel);
 
     }
     else if (cur_action_id == ROTATION)
@@ -413,18 +413,24 @@ char vwpp::TaskHoverOnQR::run(TaskID _cur_task_id, std::string _qr_inform)
         }
         // action_rotating(DynamicRecfgInterface::getInstance()->getNormalFlightAltitude());
 
-        DroneVelocity drone_velocity = action_rotating.calculateVelocity(yaw_target,
-                                                                         PX4Interface::getInstance()->getCurYaw());
 
-        geometry_msgs::Twist cmd_vel;
-        cmd_vel.linear.x = drone_velocity.x;
-        cmd_vel.linear.y = drone_velocity.y;
+        TargetPosXYZYaw target_pos_xyz_yaw = action_rotating.calculateVelocity(yaw_target,
+                                                                               PX4Interface::getInstance()->getCurYaw());
+
+        PX4Interface::getInstance()->publishTarget(target_pos_xyz_yaw);
+
+        // DroneVelocity drone_velocity = action_rotating.calculateVelocity(yaw_target,
+        //                                                                  PX4Interface::getInstance()->getCurYaw());
+
+        // geometry_msgs::Twist cmd_vel;
+        // cmd_vel.linear.x = drone_velocity.x;
+        // cmd_vel.linear.y = drone_velocity.y;
         // cmd_vel.linear.x = 0;
         // cmd_vel.linear.y = 0;
-        cmd_vel.linear.z = drone_velocity.z;
-        cmd_vel.angular.z = drone_velocity.yaw;
+        // cmd_vel.linear.z = drone_velocity.z;
+        // cmd_vel.angular.z = drone_velocity.yaw;
 
-        PX4Interface::getInstance()->publishLocalVel(cmd_vel);
+        // PX4Interface::getInstance()->publishSetpointVel(cmd_vel);
 
     }
 
@@ -433,9 +439,9 @@ char vwpp::TaskHoverOnQR::run(TaskID _cur_task_id, std::string _qr_inform)
 }
 
 
-int8_t vwpp::TaskHoverOnQR::resetHoverOnXY(double_t _hover_x, double_t _hover_y)
+int8_t vwpp::TaskHoverOnQR::resetRotatingOnXY(double_t _hover_x, double_t _hover_y)
 {
-    action_rotating.setHoverOnXY(_hover_x, _hover_y);
+    action_rotating.setRotatingOnXY(_hover_x, _hover_y);
     return 0;
 }
 
@@ -485,18 +491,19 @@ int8_t vwpp::TaskDelivering::run()
         static ActionTrackingLine action_tracking_line(
                 DynamicRecfgInterface::getInstance()->getNormalFlightAltitude());
 
-        DroneVelocity drone_velocity =
+        TargetVelXYPosZYaw target_vel_xy_pos_z_yaw =
                 action_tracking_line.calculateVelocity(
                         vwpp::VisionInterface::getInstance()->getLineOffset(),
                         vwpp::VisionInterface::getInstance()->getLineRotation());
 
-        geometry_msgs::Twist cmd_vel;
-        cmd_vel.linear.x = drone_velocity.x;
-        cmd_vel.linear.y = drone_velocity.y;
-        cmd_vel.linear.z = drone_velocity.z;
-        cmd_vel.angular.z = drone_velocity.yaw;
-
-        PX4Interface::getInstance()->publishLocalVel(cmd_vel);
+        PX4Interface::getInstance()->publishTarget(target_vel_xy_pos_z_yaw);
+        // geometry_msgs::Twist cmd_vel;
+        // cmd_vel.linear.x = drone_velocity.x;
+        // cmd_vel.linear.y = drone_velocity.y;
+        // cmd_vel.linear.z = drone_velocity.z;
+        // cmd_vel.angular.z = drone_velocity.yaw;
+        //
+        // PX4Interface::getInstance()->publishSetpointVel(cmd_vel);
     }
     else if (cur_action_id == HOVERING)
     {
@@ -513,6 +520,7 @@ int8_t vwpp::TaskDelivering::run()
                 cur_action_id = OPENCLAW;
             }
         }
+        // TODO
 
         static ActionHovering action_hovering(DynamicRecfgInterface::getInstance()->getNormalFlightAltitude());
         DroneVelocity drone_velocity =
@@ -525,7 +533,7 @@ int8_t vwpp::TaskDelivering::run()
         cmd_vel.linear.z = drone_velocity.z;
         cmd_vel.angular.z = drone_velocity.yaw;
 
-        PX4Interface::getInstance()->publishLocalVel(cmd_vel);
+        PX4Interface::getInstance()->publishSetpointVel(cmd_vel);
     }
     else if (cur_action_id == OPENCLAW)
     {
@@ -541,7 +549,7 @@ int8_t vwpp::TaskDelivering::run()
     {
 
         // TODO Maybe problems
-        if (fabs(PX4Interface::getInstance()->getCurYaw() - back_toward_yaw) <=
+        if (fmod(fabs(PX4Interface::getInstance()->getCurYaw() - back_toward_yaw), 2 * M_PI) <=
             vwpp::DynamicRecfgInterface::getInstance()->getRotateYawTolerance() * M_PI / 180.)
         {
             static JudgeAchieveCounter judge_achieve_counter(
@@ -554,17 +562,18 @@ int8_t vwpp::TaskDelivering::run()
         }
 
         static ActionRotating action_rotating(DynamicRecfgInterface::getInstance()->getNormalFlightAltitude());
-        DroneVelocity drone_velocity =
+        TargetPosXYZYaw target_pos_xyz_yaw =
                 action_rotating.calculateVelocity(back_toward_yaw,
                                                   PX4Interface::getInstance()->getCurYaw());
 
-        geometry_msgs::Twist cmd_vel;
-        cmd_vel.linear.x = drone_velocity.x;
-        cmd_vel.linear.y = drone_velocity.y;
-        cmd_vel.linear.z = drone_velocity.z;
-        cmd_vel.angular.z = drone_velocity.yaw;
+        PX4Interface::getInstance()->publishTarget(target_pos_xyz_yaw);
+        // geometry_msgs::Twist cmd_vel;
+        // cmd_vel.linear.x = drone_velocity.x;
+        // cmd_vel.linear.y = drone_velocity.y;
+        // cmd_vel.linear.z = drone_velocity.z;
+        // cmd_vel.angular.z = drone_velocity.yaw;
 
-        PX4Interface::getInstance()->publishLocalVel(cmd_vel);
+        // PX4Interface::getInstance()->publishSetpointVel(cmd_vel);
     }
 
     p_task_base->task_state = TASK_PROCESSING;
@@ -615,17 +624,18 @@ int8_t vwpp::TaskLanding::run()
 
         static ActionTrackingLine action_tracking_line(DynamicRecfgInterface::getInstance()->getNormalFlightAltitude());
 
-        DroneVelocity drone_velocity =
+        TargetVelXYPosZYaw target_vel_xy_pos_z_yaw =
                 action_tracking_line.calculateVelocity(VisionInterface::getInstance()->getLineOffset(),
                                                        VisionInterface::getInstance()->getLineRotation());
 
-        geometry_msgs::Twist cmd_vel;
-        cmd_vel.linear.x = drone_velocity.x;
-        cmd_vel.linear.y = drone_velocity.y;
-        cmd_vel.linear.z = drone_velocity.z;
-        cmd_vel.angular.z = drone_velocity.yaw;
-
-        PX4Interface::getInstance()->publishLocalVel(cmd_vel);
+        PX4Interface::getInstance()->publishTarget(target_vel_xy_pos_z_yaw);
+        // geometry_msgs::Twist cmd_vel;
+        // cmd_vel.linear.x = drone_velocity.x;
+        // cmd_vel.linear.y = drone_velocity.y;
+        // cmd_vel.linear.z = drone_velocity.z;
+        // cmd_vel.angular.z = drone_velocity.yaw;
+        //
+        // PX4Interface::getInstance()->publishSetpointVel(cmd_vel);
     }
     else if (cur_action_id == HOVERING)
     {
@@ -643,6 +653,7 @@ int8_t vwpp::TaskLanding::run()
             }
         }
 
+        // TODO
         static ActionHovering action_hovering(DynamicRecfgInterface::getInstance()->getNormalFlightAltitude());
         DroneVelocity drone_velocity = action_hovering.calculateVelocity(VisionInterface::getInstance()->getBlueHx(),
                                                                          VisionInterface::getInstance()->getBlueHy());
@@ -654,7 +665,7 @@ int8_t vwpp::TaskLanding::run()
         cmd_vel.linear.z = drone_velocity.z;
         cmd_vel.angular.z = drone_velocity.yaw;
 
-        PX4Interface::getInstance()->publishLocalVel(cmd_vel);
+        PX4Interface::getInstance()->publishSetpointVel(cmd_vel);
     }
     else if (cur_action_id == ADJUSTALTITUDE)
     {
@@ -676,16 +687,18 @@ int8_t vwpp::TaskLanding::run()
         }
 
         static ActionAdjustAltitude action_adjust_altitude;
-        DroneVelocity drone_velocity = action_adjust_altitude.calculateVelocity(altitude_target,
-                                                                                PX4Interface::getInstance()->getCurZ());
+        TargetPosXYZYaw target_pos_xyz_yaw
+                = action_adjust_altitude.calculateVelocity(altitude_target,
+                                                           PX4Interface::getInstance()->getCurZ());
 
-        geometry_msgs::Twist cmd_vel;
-        cmd_vel.linear.x = drone_velocity.x;
-        cmd_vel.linear.y = drone_velocity.y;
-        cmd_vel.linear.z = drone_velocity.z;
-        cmd_vel.angular.z = drone_velocity.yaw;
-
-        PX4Interface::getInstance()->publishLocalVel(cmd_vel);
+        PX4Interface::getInstance()->publishTarget(target_pos_xyz_yaw);
+        // geometry_msgs::Twist cmd_vel;
+        // cmd_vel.linear.x = drone_velocity.x;
+        // cmd_vel.linear.y = drone_velocity.y;
+        // cmd_vel.linear.z = drone_velocity.z;
+        // cmd_vel.angular.z = drone_velocity.yaw;
+        //
+        // PX4Interface::getInstance()->publishSetpointVel(cmd_vel);
 
     }
 
@@ -749,18 +762,19 @@ int8_t vwpp::TaskTakeoff::run()
         }
 
         static ActionAdjustAltitude action_adjust_altitude;
-        DroneVelocity drone_velocity =
+        TargetPosXYZYaw target_pos_xyz_yaw =
                 action_adjust_altitude.calculateVelocity(altitude_target,
                                                          PX4Interface::getInstance()->getCurZ());
 
+        PX4Interface::getInstance()->publishTarget(target_pos_xyz_yaw);
 
-        geometry_msgs::Twist cmd_vel;
-        cmd_vel.linear.x = drone_velocity.x;
-        cmd_vel.linear.y = drone_velocity.y;
-        cmd_vel.linear.z = drone_velocity.z;
-        cmd_vel.angular.z = drone_velocity.yaw;
-
-        PX4Interface::getInstance()->publishLocalVel(cmd_vel);
+        // geometry_msgs::Twist cmd_vel;
+        // cmd_vel.linear.x = drone_velocity.x;
+        // cmd_vel.linear.y = drone_velocity.y;
+        // cmd_vel.linear.z = drone_velocity.z;
+        // cmd_vel.angular.z = drone_velocity.yaw;
+        //
+        // PX4Interface::getInstance()->publishSetpointVel(cmd_vel);
     }
 
     p_task_base->task_state = TASK_PROCESSING;

--- a/src/controller/Task.h
+++ b/src/controller/Task.h
@@ -142,7 +142,7 @@ namespace vwpp
 
         int8_t run(GateType _gate_type);
 
-        int8_t resetAdjustAltitudeOnXY(double_t _hover_x, double_t _hover_y, double_t _hold_yaw);
+        int8_t resetAdjustAltitudeOnXYYaw(double_t _hover_x, double_t _hover_y, double_t _hold_yaw);
 
     private:
 
@@ -180,10 +180,9 @@ namespace vwpp
 
     private:
         TaskBase* p_task_base;
-
-        // TODO Add to task_base
         ActionID cur_action_id;
 
+        // TODO
         ActionRotating action_rotating;
     };
 
@@ -204,8 +203,11 @@ namespace vwpp
     private:
 
         TaskBase* p_task_base;
-
         ActionID cur_action_id;
+
+        ActionTrackingLine* p_action_tracking_line;
+        ActionHovering* p_action_hovering;
+        ActionRotating* p_action_rotating;
     };
 
 
@@ -226,9 +228,11 @@ namespace vwpp
     private:
 
         TaskBase* p_task_base;
-
         ActionID cur_action_id;
 
+        ActionTrackingLine* p_action_tracking_line;
+        ActionHovering* p_action_hovering;
+        ActionAdjustAltitude* p_action_adjust_altitude;
     };
 
 }

--- a/src/controller/Task.h
+++ b/src/controller/Task.h
@@ -46,6 +46,12 @@ namespace vwpp
         TASK_FINISH
     };
 
+    enum ActionRuntime
+    {
+        FIRST_IN = 1,
+        SECOND_IN
+    };
+
     class TaskBase
     {
     public:
@@ -147,11 +153,13 @@ namespace vwpp
         double_t altitude_target;
 
         ActionAdjustAltitude* p_action_adjust_altitude;
-        ActionTrackingLine* p_action_tracking_line;
+        ActionTrackingLine* p_action_tracking_line{};
 
 
         // TODO Timer
         int64_t forward_counter;
+
+        ActionRuntime inter_adjust_altitude_time;
     };
 
     class TaskHoverOnQR

--- a/src/controller/Task.h
+++ b/src/controller/Task.h
@@ -106,6 +106,8 @@ namespace vwpp
 
         TaskBase* p_task_base;
 
+        ActionTrackingLine* p_action_tracking_line;
+
         ActionID cur_action_id;
 
         int64_t runtime;
@@ -134,6 +136,8 @@ namespace vwpp
 
         int8_t run(GateType _gate_type);
 
+        int8_t resetAdjustAltitudeOnXY(double_t _hover_x, double_t _hover_y, double_t _hold_yaw);
+
     private:
 
         TaskBase* p_task_base;
@@ -141,6 +145,10 @@ namespace vwpp
         ActionID cur_action_id;
 
         double_t altitude_target;
+
+        ActionAdjustAltitude* p_action_adjust_altitude;
+        ActionTrackingLine* p_action_tracking_line;
+
 
         // TODO Timer
         int64_t forward_counter;

--- a/src/controller/Task.h
+++ b/src/controller/Task.h
@@ -160,7 +160,7 @@ namespace vwpp
 
         char run(TaskID _cur_task_id, std::string _qr_inform);
 
-        int8_t resetHoverOnXY(double_t _hover_x, double_t _hover_y);
+        int8_t resetRotatingOnXY(double_t _hover_x, double_t _hover_y);
 
     private:
         TaskBase* p_task_base;

--- a/src/interface/PX4Interface.cpp
+++ b/src/interface/PX4Interface.cpp
@@ -252,7 +252,7 @@ int8_t PX4Interface::publishTarget(const TargetPosXYZYaw _target_pos_xyz_yaw)
     position_target.yaw = _target_pos_xyz_yaw.yaw;
 
     boost::unique_lock<boost::mutex> uq_lock_raw(mutex_cmd_pub);
-    this->px4_setpoint_raw_pub.publish(_target_pos_xyz_yaw);
+    this->px4_setpoint_raw_pub.publish(position_target);
     return 0;
 }
 
@@ -273,7 +273,7 @@ int8_t PX4Interface::publishTarget(const TargetVelXYPosZYaw _target_vel_xy_pos_z
     position_target.yaw = _target_vel_xy_pos_z_yaw.yaw;
 
     boost::unique_lock<boost::mutex> uq_lock_raw(mutex_cmd_pub);
-    this->px4_setpoint_raw_pub.publish(_target_vel_xy_pos_z_yaw);
+    this->px4_setpoint_raw_pub.publish(position_target);
     return 0;
 }
 

--- a/src/interface/PX4Interface.cpp
+++ b/src/interface/PX4Interface.cpp
@@ -24,11 +24,14 @@ PX4Interface::PX4Interface() :
     px4_pose_sub = nh.subscribe<geometry_msgs::PoseStamped>
             ("/mavros/local_position/pose", 1, &PX4Interface::px4_pose_cb, this);
 
-    px4_vel_pub = nh.advertise<geometry_msgs::Twist>
+    px4_setpoint_vel_pub = nh.advertise<geometry_msgs::Twist>
             ("/mavros/setpoint_velocity/cmd_vel_unstamped", 1);
 
-    px4_pose_pub = nh.advertise<geometry_msgs::PoseStamped>
+    px4_setpoint_pose_pub = nh.advertise<geometry_msgs::PoseStamped>
             ("/mavros/setpoint_position/local", 10);
+
+    px4_setpoint_raw_pub = nh.advertise<mavros_msgs::PositionTarget>
+            ("/mavros/setpoint_raw/local", 1);
 
     // Wait for FCU connection
     while (ros::ok() && !px4_cur_state.connected)
@@ -125,7 +128,7 @@ int8_t PX4Interface::switchOffboard()
         temp_pose.pose.position.y = 0;
         temp_pose.pose.position.z = 1;
 
-        vwpp::PX4Interface::getInstance()->publishLocalPose(temp_pose);
+        vwpp::PX4Interface::getInstance()->publishSetpointPose(temp_pose);
         ros::spinOnce();
         loop_rate.sleep();
     }
@@ -157,7 +160,7 @@ int8_t PX4Interface::unlockVehicle()
         temp_pose.pose.position.x = 0;
         temp_pose.pose.position.y = 0;
         temp_pose.pose.position.z = 1;
-        vwpp::PX4Interface::getInstance()->publishLocalPose(temp_pose);
+        vwpp::PX4Interface::getInstance()->publishSetpointPose(temp_pose);
         ros::spinOnce();
         loop_rate.sleep();
     }
@@ -212,21 +215,66 @@ void PX4Interface::px4_pose_cb(const geometry_msgs::PoseStamped::ConstPtr &msg)
 }
 
 
-int8_t PX4Interface::publishLocalVel(const geometry_msgs::Twist &_vel)
+int8_t PX4Interface::publishSetpointVel(const geometry_msgs::Twist &_vel)
 {
-    boost::unique_lock<boost::mutex> uq_lock_vel(mutex_vel_pub);
+    boost::unique_lock<boost::mutex> uq_lock_vel(mutex_cmd_pub);
 
     ROS_INFO("%lf,%lf,%lf,%lf", _vel.linear.x, _vel.linear.y, _vel.linear.z, _vel.angular.z);
-    this->px4_vel_pub.publish(_vel);
+    this->px4_setpoint_vel_pub.publish(_vel);
+
+    return 0;
 }
 
 
-int8_t PX4Interface::publishLocalPose(const geometry_msgs::PoseStamped &_pose)
+int8_t PX4Interface::publishSetpointPose(const geometry_msgs::PoseStamped &_pose)
 {
-    boost::unique_lock<boost::mutex> uq_lock_pose(mutex_vel_pose);
-    this->px4_pose_pub.publish(_pose);
+    boost::unique_lock<boost::mutex> uq_lock_pose(mutex_cmd_pub);
+    this->px4_setpoint_pose_pub.publish(_pose);
+
+    return 0;
 }
 
 
+int8_t PX4Interface::publishTarget(const TargetPosXYZYaw _target_pos_xyz_yaw)
+{
+
+    mavros_msgs::PositionTarget position_target;
+    position_target.coordinate_frame = position_target.FRAME_LOCAL_NED;
+    position_target.type_mask =
+            position_target.IGNORE_AFX | position_target.IGNORE_AFY | position_target.IGNORE_AFZ |
+            // position_target.IGNORE_PX | position_target.IGNORE_PY | position_target.IGNORE_PZ |
+            position_target.IGNORE_VZ | position_target.IGNORE_VY | position_target.IGNORE_VZ |
+            position_target.IGNORE_YAW_RATE;
+
+    position_target.position.x = _target_pos_xyz_yaw.px;
+    position_target.position.y = _target_pos_xyz_yaw.py;
+    position_target.position.z = _target_pos_xyz_yaw.pz;
+    position_target.yaw = _target_pos_xyz_yaw.yaw;
+
+    boost::unique_lock<boost::mutex> uq_lock_raw(mutex_cmd_pub);
+    this->px4_setpoint_raw_pub.publish(_target_pos_xyz_yaw);
+    return 0;
+}
+
+
+int8_t PX4Interface::publishTarget(const TargetVelXYPosZYaw _target_vel_xy_pos_z_yaw)
+{
+    mavros_msgs::PositionTarget position_target;
+    position_target.coordinate_frame = position_target.FRAME_LOCAL_NED;
+    position_target.type_mask =
+            position_target.IGNORE_AFX | position_target.IGNORE_AFY | position_target.IGNORE_AFZ |
+            position_target.IGNORE_PX | position_target.IGNORE_PY | // position_target.IGNORE_PZ |
+            // position_target.IGNORE_VZ | position_target.IGNORE_VY | position_target.IGNORE_VZ |
+            position_target.IGNORE_YAW_RATE;
+
+    position_target.velocity.x = _target_vel_xy_pos_z_yaw.vx;
+    position_target.velocity.y = _target_vel_xy_pos_z_yaw.vy;
+    position_target.position.z = _target_vel_xy_pos_z_yaw.pz;
+    position_target.yaw = _target_vel_xy_pos_z_yaw.yaw;
+
+    boost::unique_lock<boost::mutex> uq_lock_raw(mutex_cmd_pub);
+    this->px4_setpoint_raw_pub.publish(_target_vel_xy_pos_z_yaw);
+    return 0;
+}
 
 

--- a/src/interface/PX4Interface.h
+++ b/src/interface/PX4Interface.h
@@ -11,6 +11,7 @@
 #include <mavros_msgs/State.h>
 #include <mavros_msgs/SetMode.h>
 #include <mavros_msgs/CommandBool.h>
+#include <mavros_msgs/PositionTarget.h>
 #include <geometry_msgs/PoseStamped.h>
 #include <geometry_msgs/TwistStamped.h>
 #include <tf/transform_datatypes.h>
@@ -19,6 +20,22 @@
 
 namespace vwpp
 {
+    struct TargetVelXYPosZYaw
+    {
+        double_t vx;
+        double_t vy;
+        double_t pz;
+        double_t yaw;
+    };
+
+    struct TargetPosXYZYaw
+    {
+        double_t px;
+        double_t py;
+        double_t pz;
+        double_t yaw;
+    };
+
     class PX4Interface
     {
     public:
@@ -41,10 +58,13 @@ namespace vwpp
 
         double_t getCurZ();
 
-        int8_t publishLocalVel(const geometry_msgs::Twist &_vel);
+        int8_t publishSetpointVel(const geometry_msgs::Twist &_vel);
 
-        int8_t publishLocalPose(const geometry_msgs::PoseStamped &_pose);
+        int8_t publishSetpointPose(const geometry_msgs::PoseStamped &_pose);
 
+        int8_t publishTarget(const TargetPosXYZYaw _target_pos_xyz_yaw);
+
+        int8_t publishTarget(const TargetVelXYPosZYaw _target_vel_xy_pos_z_yaw);
 
     private:
 
@@ -69,11 +89,11 @@ namespace vwpp
         ros::ServiceClient px4_arming_client;
         ros::ServiceClient px4_set_mode_client;
         ros::Subscriber px4_pose_sub;
-        ros::Publisher px4_vel_pub;
-        ros::Publisher px4_pose_pub;
+        ros::Publisher px4_setpoint_vel_pub;
+        ros::Publisher px4_setpoint_pose_pub;
+        ros::Publisher px4_setpoint_raw_pub;
 
-        boost::mutex mutex_vel_pub;
-        boost::mutex mutex_vel_pose;
+        boost::mutex mutex_cmd_pub;
 
         mavros_msgs::State px4_cur_state;
         mavros_msgs::SetMode px4_offb_set_mode;

--- a/src/vision/alldefine.h
+++ b/src/vision/alldefine.h
@@ -1,7 +1,7 @@
 #ifndef ALLDEFINE_H
 #define ALLDEFINE_H
 
-//#define TEST
+#define TEST
 #define TEST_ROS
 
 //#define USE_HSV

--- a/src/vision/mycv.cpp
+++ b/src/vision/mycv.cpp
@@ -443,21 +443,20 @@ void MYCV::findQR(cv::Mat image)
 
         QR_location[0] = QR_X/4.0;
         QR_location[1] = QR_Y/4.0;
-
 #ifdef TEST
         cv::circle(outimage, cv::Point2d(QR_location[0], QR_location[1]), 5, cv::Scalar(0,255,0), 3);
         cv::circle(outimage, cv::Point2d(QR_location[0], QR_location[1]), 20, cv::Scalar(0,255,0), 5);
 #endif
-
-        resetpoint(QR_location, image);
     }
+
+    int QR_rect_size = 170;
 
     if(inform.empty())
     {
         detect_QR = false;
         QR_inform = "";
     }
-    else if(fabs(QR_location[0])<170 && fabs(QR_location[1])<170)
+    else if(fabs(QR_location[0])<QR_rect_size && fabs(QR_location[1])<QR_rect_size)
     {
         detect_QR = true;
         QR_inform = inform[0];
@@ -472,8 +471,12 @@ void MYCV::findQR(cv::Mat image)
         QR_inform = ss;
 
 #ifdef TEST
+        cv::rectangle(outimage, cv::Point(outimage.cols/2-QR_rect_size, outimage.rows/2-QR_rect_size),
+                cv::Point(outimage.cols/2+QR_rect_size, outimage.rows/2+QR_rect_size), cv::Scalar(255,255,0));
         cv::circle(outimage, cv::Point2d(QR_location[0], QR_location[1]), 3, cv::Scalar(0,255,255), 3);
 #endif
+
+        resetpoint(QR_location, image);
     }
     else
     {

--- a/src/vision/mycv.cpp
+++ b/src/vision/mycv.cpp
@@ -569,8 +569,8 @@ void MYCV::findblueH(cv::Mat image)
     if (number_blue>image.rows*image.cols/25)
     {
         detect_blueH = true;
-        blueH_location[0] = 1.0* sum_blue_rows / number_blue;
-        blueH_location[1] = 1.0* sum_blue_cols / number_blue;
+        blueH_location[1] = 1.0* sum_blue_rows / number_blue;
+        blueH_location[0] = 1.0* sum_blue_cols / number_blue;
 
 #ifdef TEST
         cv::circle(outimage, cv::Point2d(blueH_location[0], blueH_location[1]), 5, cv::Scalar(255,0,0), 3);
@@ -672,8 +672,8 @@ void MYCV::findredX(cv::Mat image)
     if (number_red>image.rows*image.cols/25)
     {
         detect_redX = true;
-        redX_location[0] = 1.0* sum_red_rows / number_red;
-        redX_location[1] = 1.0* sum_red_cols / number_red;
+        redX_location[1] = 1.0* sum_red_rows / number_red;
+        redX_location[0] = 1.0* sum_red_cols / number_red;
 
 #ifdef TEST
         cv::circle(outimage, cv::Point2d(redX_location[0], redX_location[1]), 5, cv::Scalar(0,0,255), 3);

--- a/src/vision/mycv.h
+++ b/src/vision/mycv.h
@@ -14,7 +14,7 @@
 #include <cv_bridge/cv_bridge.h>
 #include <image_transport/image_transport.h>
 #include <dynamic_reconfigure/server.h>
-// #include "../../../devel/include/my_cv/vision_dynamic_reconfigureConfig.h"
+#include "fira_esi/vision_dynamic_reconfigureConfig.h"
 #endif
 
 #include <algorithm>


### PR DESCRIPTION
1. 重写了Action的部分底层.调用mavros的setpoint_raw接口,实现xy, z, yaw的分开控制.yaw角不控角速率,直接控角位置.
2. 实物飞机测试完成. 恢复到之前的扫码巡线状态. 新底层的控制的确更快更稳一些.
3. 删掉了之前Task执行流程中的static Action, 为满足使用需求增加了保存与更新状态的接口.
4. 开始调试实物其他任务.